### PR TITLE
Use native file input mechanism

### DIFF
--- a/demystify-lite.py
+++ b/demystify-lite.py
@@ -7,8 +7,8 @@ file-system. The file is processed and the results returned to the page.
 
 import tempfile
 
-from js import Object, document, window
-from pyodide import create_proxy, to_js
+from js import document
+from pyodide import create_proxy
 
 from demystify.demystify import analysis_from_csv, handle_output
 
@@ -32,17 +32,9 @@ async def file_select(event):
     event.stopPropagation()
     event.preventDefault()
 
-    try:
-        options = {"multiple": False, "startIn": "documents"}
-        fileHandles = await window.showOpenFilePicker(
-            Object.fromEntries(to_js(options))
-        )
-    except Exception as err:
-        console.log(f"Exception: {err}")
-        return
+    files = event.target.files
 
-    for fileHandle in fileHandles:
-        file = await fileHandle.getFile()
+    for file in files:
         document.getElementById("filename").innerHTML = f"<b>File Name:</b> {file.name}"
         document.getElementById("filesize").innerHTML = f"<b>File Size:</b> {file.size}"
         if file.type:
@@ -51,7 +43,7 @@ async def file_select(event):
             ).innerHTML = f"<b>File Type:</b> {file.type}"
         document.getElementById(
             "filedate"
-        ).innerHTML = f"<b>File date:</b> {file.lastModifiedDate}"
+        ).innerHTML = f"<b>File date:</b> {file.lastModified}"
         content = await file.text()
 
         a = tempfile.NamedTemporaryFile("w", encoding="UTF8")
@@ -71,8 +63,8 @@ async def file_select(event):
 def setup_button():
     """Create a Python proxy for the callback function."""
     file_select_proxy = create_proxy(file_select)
-    document.getElementById("file_select").addEventListener(
-        "click", file_select_proxy, False
+    document.querySelector("#file_select input[type='file']").addEventListener(
+        "change", file_select_proxy, False
     )
 
 

--- a/index.htm
+++ b/index.htm
@@ -38,17 +38,8 @@ Ross
       <link rel="icon" type="image/png" href="favicon.png" />
    </head>
    <body>
-      <!-- <py-repl id="my-repl" auto-generate="true"></py-repl> -->
       <py-script src="./demystify-lite.py"></py-script>
-      <section class="noprint">
-         <div class="banner">
-            <b>Please note</b>, this application will not work in Firefox as
-            Mozilla have limited support for
-            <a class="banner_link"
-               href="https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker#browser_compatibility"
-               target="_blank">the File API</a>
-         </div>
-      </section>
+      <!-- <py-repl id="my-repl" auto-generate="true"></py-repl> -->
       <main>
          <section class="noprint">
             <div>
@@ -81,29 +72,27 @@ Ross
                   shared with a server and so it can be safely used on data without
                   revealing your secrets to the world. This implementation is
                   enabled by
-                  <a href="https://pyscript.net/" target="_blank">pyscript</a>.
+                  <a href="https://pyscript.net/" target="_blank" rel="noopener">pyscript</a>.
                </p>
-               <p>
                <p>
                   More information:
                <ul>
-                  <li>Demystify full-fat on <a href="https://github.com/exponential-decay/demystify" target="_blank">Github</a>.</li>
-                  <li>Understanding file-format identification reports on <a href="https://journal.code4lib.org/articles/16351" target="_blank">Code4Lib</a>.</li>
-                  <li>Siegfried on <a href="https://github.com/richardlehane/siegfried" target="_blank">GitHub</a>.</li>
-                  <li>DROID at <a href="https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/" target="_blank">The National Archives, UK</a>.</li>
-                  <li>Demystify Lite py-wheel commit: <a href="https://github.com/exponential-decay/demystify/commit/bed3c4b08aa9c04da7978f156f1fa8bf6fc7ac9e" target="_blank">97ef14</a>.</li>
-                  <li>Demystify Lite repository and <a href="https://github.com/ross-spencer/demystify-lite/issues" target="_blank">issues</a>.</li>
+                  <li>Demystify full-fat on <a href="https://github.com/exponential-decay/demystify" target="_blank" rel="noopener">Github</a>.</li>
+                  <li>Understanding file-format identification reports on <a href="https://journal.code4lib.org/articles/16351" target="_blank" rel="noopener">Code4Lib</a>.</li>
+                  <li>Siegfried on <a href="https://github.com/richardlehane/siegfried" target="_blank" rel="noopener">GitHub</a>.</li>
+                  <li>DROID at <a href="https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/" target="_blank" rel="noopener">The National Archives, UK</a>.</li>
+                  <li>Demystify Lite py-wheel commit: <a href="https://github.com/exponential-decay/demystify/commit/bed3c4b08aa9c04da7978f156f1fa8bf6fc7ac9e" target="_blank" rel="noopener">97ef14</a>.</li>
+                  <li>Demystify Lite repository and <a href="https://github.com/ross-spencer/demystify-lite/issues" target="_blank" rel="noopener">issues</a>.</li>
                </ul>
                </p>
             </div>
             <p>Open a DROID or Siegfried report in the browser to analyze it.</p>
-            </div>
          </section>
          <section class="noprint">
             <div class="drag" id="drop_zone">
                <div id="file_select">
                   <label class="custom-file-upload">
-                     <input type="file" name="files[]" single disabled />
+                     <input type="file" name="files[]" />
                   Select a file-format-report from your computer
                   </label>
                </div>


### PR DESCRIPTION
Instead of using the `showOpenFilePicker` API which is not currently supported everywhere (especially on Firefox), we can just use the native events of the file input instead. While at it I also fixed problems in the markup and added `rel="noopener"` attributes to links as is good privacy practice and suggested by Webhint.

Fixes #7.